### PR TITLE
Support inline queries

### DIFF
--- a/vxtelegram/telegram.py
+++ b/vxtelegram/telegram.py
@@ -3,7 +3,7 @@ import json
 from treq.client import HTTPClient
 
 from twisted.internet import reactor
-from twisted.internet.defer import inlineCallbacks
+from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.web import http
 from twisted.web.client import Agent
 
@@ -75,49 +75,16 @@ class TelegramTransport(HttpRpcTransport):
             allow_redirects=False,
         )
 
-        # Telegram redirects our request if our token is in an invalid format
-        if r.code == http.FOUND:
-            self.log.warning('Webhook setup failed: request redirected')
-            yield self.add_status_bad_webhook(
-                status_type='request_redirected',
-                message='Webhook setup failed: request redirected',
-                details={
-                    'error': 'Unexpected redirect',
-                    'res_code': http.FOUND,
-                },
-            )
-            return
-
-        try:
-            res = yield r.json()
-        except ValueError as e:
-            content = yield r.content()
-            self.log.warning(
-                'Webhook setup failed: unexpected response format'
-            )
-            yield self.add_status_bad_webhook(
-                status_type='unexpected_response_format',
-                message='Webhook setup failed: unexpected response format',
-                details={
-                    'error': e.message,
-                    'res_code': r.code,
-                    'res_body': content,
-                },
-            )
-            return
-
-        if r.code == http.OK and res['ok']:
+        validate = yield self.validate_outbound(r)
+        if validate['success']:
             self.log.info('Webhook set up on %s' % self.inbound_url)
             yield self.add_status_good_webhook()
         else:
-            self.log.warning('Webhook setup failed: %s' % res['description'])
+            self.log.warning('Webhook setup failed: %s' % validate['message'])
             yield self.add_status_bad_webhook(
-                status_type='bad_response',
-                message='Webhook setup failed: bad response from Telegram',
-                details={
-                    'error': res['description'],
-                    'res_code': r.code,
-                }
+                status_type=validate['status'],
+                message='Webhook setup failed: %s' % validate['message'],
+                details=validate['details'],
             )
 
     def add_status_good_webhook(self):
@@ -233,7 +200,7 @@ class TelegramTransport(HttpRpcTransport):
             from_addr=inline_query['from']['id'],
             transport_type=self.transport_type,
             transport_name=self.transport_name,
-            transport_metadata={
+            helper_metadata={
                 'message_type': 'inline_query',
                 'details': {
                     'query': inline_query['query'],
@@ -272,6 +239,14 @@ class TelegramTransport(HttpRpcTransport):
     def handle_outbound_message(self, message):
         # TODO: handle direct replies
         message_id = message['message_id']
+
+        # Handle replies to inline queries separately from text messages
+        if 'type' in message['transport_metadata']:
+            is_inline = (message['transport_metadata']['type'] == 'inline')
+            if is_inline:
+                yield self.handle_outbound_inline_query(message_id, message)
+                return
+
         outbound_msg = {
             'chat_id': message['to_addr'],
             'text': message['content'],
@@ -286,47 +261,93 @@ class TelegramTransport(HttpRpcTransport):
             allow_redirects=False,
         )
 
-        # Telegram redirects our request if our bot token is invalid
-        if r.code == http.FOUND:
-            yield self.outbound_failure(
-                message_id=message_id,
-                message='Message not sent: request redirected',
-                status_type='request_redirected',
-                details={
-                    'error': 'Unexpected redirect',
-                    'res_code': http.FOUND,
-                },
-            )
-            return
-
-        try:
-            res = yield r.json()
-        except ValueError as e:
-            content = yield r.content()
-            yield self.outbound_failure(
-                message_id=message_id,
-                message='Message not sent: unexpected response format',
-                status_type='unexpected_response_format',
-                details={
-                    'error': e.message,
-                    'res_code': r.code,
-                    'res_body': content,
-                },
-            )
-            return
-
-        if r.code == http.OK and res['ok']:
+        validate = yield self.validate_outbound(r)
+        if validate['success']:
             yield self.outbound_success(message_id)
         else:
             yield self.outbound_failure(
                 message_id=message_id,
-                message='Message not sent: bad response from Telegram',
-                status_type='bad_response',
-                details={
-                    'error': res['description'],
-                    'res_code': r.code,
-                },
+                message='Message not sent: %s' % validate['message'],
+                status_type=validate['status'],
+                details=validate['details'],
             )
+
+    @inlineCallbacks
+    def handle_outbound_inline_query(self, message_id, message):
+        """
+        Handles replies to inline queries. We rely on the application worker to
+        generate the result(s) and we trust that they're in the correct format.
+        """
+        url = self.get_outbound_url('answerInlineQuery')
+        http_client = HTTPClient(self.agent_factory())
+
+        outbound_query_answer = {
+            'inline_query_id': message['transport_metadata']['query_id'],
+            'results': message['transport_metadata']['results'],
+        }
+
+        r = yield http_client.post(
+            url=url,
+            data=json.dumps(outbound_query_answer),
+            headers={'Content-Type': ['application/json']},
+            allow_redirects=False,
+        )
+
+        validate = yield self.validate_outbound(r)
+        if validate['success']:
+            yield self.outbound_success(message_id)
+        else:
+            yield self.outbound_failure(
+                message_id=message_id,
+                message='Query reply not sent: %s' % validate['message'],
+                status_type=validate['status'],
+                details=validate['details'],
+            )
+
+    @inlineCallbacks
+    def validate_outbound(self, response):
+        """
+        Checks whether a request to Telegram's API was successful, and returns
+        relevant information for publishing nacks / statuses if not.
+        """
+        if response.code == http.FOUND:
+            returnValue({
+                'success': False,
+                'message': 'request redirected',
+                'status': 'request_redirected',
+                'details': {
+                    'error': 'Unexpected redirect',
+                    'res_code': http.FOUND
+                },
+            })
+
+        try:
+            res = yield response.json()
+        except ValueError as e:
+            content = yield response.content()
+            returnValue({
+                'success': False,
+                'message': 'unexpected response format',
+                'status': 'unexpected_response_format',
+                'details': {
+                    'error': e.message,
+                    'res_code': response.code,
+                    'res_body': content,
+                },
+            })
+
+        if response.code == http.OK and res['ok']:
+            returnValue({'success': True})
+        else:
+            returnValue({
+                'success': False,
+                'message': 'bad response from Telegram',
+                'status': 'bad_response',
+                'details': {
+                    'error': res['description'],
+                    'res_code': response.code,
+                },
+            })
 
     @inlineCallbacks
     def outbound_failure(self, status_type, message_id, message, details):

--- a/vxtelegram/telegram.py
+++ b/vxtelegram/telegram.py
@@ -146,7 +146,6 @@ class TelegramTransport(HttpRpcTransport):
     @inlineCallbacks
     def handle_raw_inbound_message(self, message_id, request):
         # TODO: ensure we are not receiving duplicate updates
-        # TODO: support inline queries
         content = yield request.content.read()
         try:
             update = json.loads(content)

--- a/vxtelegram/telegram.py
+++ b/vxtelegram/telegram.py
@@ -265,6 +265,7 @@ class TelegramTransport(HttpRpcTransport):
         if validate['success']:
             yield self.outbound_success(message_id)
         else:
+            # TODO: add a test for this eventuality
             yield self.outbound_failure(
                 message_id=message_id,
                 message='Message not sent: %s' % validate['message'],
@@ -278,6 +279,10 @@ class TelegramTransport(HttpRpcTransport):
         Handles replies to inline queries. We rely on the application worker to
         generate the result(s) and we trust that they're in the correct format.
         """
+        # NB: while testing replies to inline queries with curl, every single
+        #     request got a 401 (invalid query_id) response, even though the
+        #     query_id existed and was valid each time. It's possible that this
+        #     method isn't the correct way to implement answerInlineQuery.
         url = self.get_outbound_url('answerInlineQuery')
         http_client = HTTPClient(self.agent_factory())
 

--- a/vxtelegram/telegram.py
+++ b/vxtelegram/telegram.py
@@ -279,10 +279,9 @@ class TelegramTransport(HttpRpcTransport):
         Handles replies to inline queries. We rely on the application worker to
         generate the result(s) and we trust that they're in the correct format.
         """
-        # NB: while testing replies to inline queries with curl, every single
-        #     request got a 401 (invalid query_id) response, even though the
-        #     query_id existed and was valid each time. It's possible that this
-        #     method isn't the correct way to implement answerInlineQuery.
+        # NB: inline query ids expire shockingly fast it seems. If we don't
+        #     reply to a query within a matter of seconds, our request gets a
+        #     400 response with a "QUERY_ID_INVALID" description in the body.
         url = self.get_outbound_url('answerInlineQuery')
         http_client = HTTPClient(self.agent_factory())
 

--- a/vxtelegram/telegram.py
+++ b/vxtelegram/telegram.py
@@ -305,6 +305,7 @@ class TelegramTransport(HttpRpcTransport):
         if validate['success']:
             yield self.outbound_success(message_id)
         else:
+            validate['details'].update({'inline_query_id': inline_query_id})
             yield self.outbound_failure(
                 message_id=message_id,
                 message='Query reply not sent: %s' % validate['message'],

--- a/vxtelegram/telegram.py
+++ b/vxtelegram/telegram.py
@@ -195,15 +195,21 @@ class TelegramTransport(HttpRpcTransport):
 
         yield self.publish_message(
             message_id=message_id,
-            content=None,
+            content=inline_query['query'],
             to_addr=self.bot_username,
             from_addr=inline_query['from']['id'],
             transport_type=self.transport_type,
             transport_name=self.transport_name,
             helper_metadata={
-                'message_type': 'inline_query',
+                'type': 'inline_query',
                 'details': {
-                    'query': inline_query['query'],
+                    'query_id': inline_query['id'],
+                },
+            },
+            transport_metadata={
+                'type': 'inline_query',
+                'details': {
+                    'query_id': inline_query['id'],
                 },
             },
         )

--- a/vxtelegram/tests/test_telegram.py
+++ b/vxtelegram/tests/test_telegram.py
@@ -358,16 +358,21 @@ class TestTelegramTransport(VumiTestCase):
         })
 
         [msg] = yield self.helper.wait_for_dispatched_inbound(1)
-        self.assertEqual(msg['content'], 'Do something, bot!')
+        self.assertEqual(msg['content'], update['inline_query']['query'])
         self.assertEqual(msg['to_addr'], self.bot_username)
         self.assertEqual(msg['from_addr'], self.default_user['id'])
         self.assertEqual(msg['transport_type'], transport.transport_type)
         self.assertEqual(msg['transport_name'], transport.transport_name)
         self.assertEqual(msg['helper_metadata'], {
-            'type': 'inline_query',
-            'details': {'query_id': '1234'},
+            'telegram': {
+                'type': 'inline_query',
+                'details': {'inline_query_id': update['inline_query']['id']}
+            }
         })
-        self.assertEqual(msg['transport_metadata'], msg['helper_metadata'])
+        self.assertEqual(msg['transport_metadata'], {
+            'type': 'inline_query',
+            'details': {'query_id': update['inline_query']['id']}
+        })
 
     @inlineCallbacks
     def test_inbound_non_message_update(self):
@@ -455,9 +460,16 @@ class TestTelegramTransport(VumiTestCase):
             to_addr=self.default_user['id'],
             from_addr=self.bot_username,
             transport_metadata={
-                'type': 'inline',
-                'query_id': '1234',
-                'results': results,
+                'type': 'inline_query',
+                'details': {
+                    'query_id': '1234',
+                },
+            },
+            helper_metadata={
+                'telegram': {
+                    'type': 'inline_query_reply',
+                    'results': results,
+                },
             },
         )
         d = self.helper.dispatch_outbound(msg)

--- a/vxtelegram/tests/test_telegram.py
+++ b/vxtelegram/tests/test_telegram.py
@@ -335,7 +335,7 @@ class TestTelegramTransport(VumiTestCase):
         update = {
             'update_id': 'update_id',
             'inline_query': {
-                'id': 1234,
+                'id': "1234",
                 'from': self.default_user,
                 'query': 'Do something, bot!'
             }
@@ -358,15 +358,16 @@ class TestTelegramTransport(VumiTestCase):
         })
 
         [msg] = yield self.helper.wait_for_dispatched_inbound(1)
-        self.assertEqual(msg['content'], None)
+        self.assertEqual(msg['content'], 'Do something, bot!')
         self.assertEqual(msg['to_addr'], self.bot_username)
         self.assertEqual(msg['from_addr'], self.default_user['id'])
         self.assertEqual(msg['transport_type'], transport.transport_type)
         self.assertEqual(msg['transport_name'], transport.transport_name)
         self.assertEqual(msg['helper_metadata'], {
-            'message_type': 'inline_query',
-            'details': {'query': 'Do something, bot!'}
+            'type': 'inline_query',
+            'details': {'query_id': '1234'},
         })
+        self.assertEqual(msg['transport_metadata'], msg['helper_metadata'])
 
     @inlineCallbacks
     def test_inbound_non_message_update(self):

--- a/vxtelegram/tests/test_telegram.py
+++ b/vxtelegram/tests/test_telegram.py
@@ -83,10 +83,12 @@ class TestTelegramTransport(VumiTestCase):
 
         # Ignore status published during webhook setup
         [status, _] = yield self.helper.wait_for_dispatched_statuses()
-        self.assertEqual(status['status'], 'down')
-        self.assertEqual(status['component'], 'telegram_setup')
-        self.assertEqual(status['type'], 'starting')
-        self.assertEqual(status['message'], 'Telegram transport starting...')
+        self.assert_status(status, {
+            'status': 'down',
+            'component': 'telegram_setup',
+            'type': 'starting',
+            'message': 'Telegram transport starting...',
+        })
 
     @inlineCallbacks
     def test_get_outbound_url(self):
@@ -126,11 +128,13 @@ class TestTelegramTransport(VumiTestCase):
 
         # Ignore statuses published on transport startup
         [_, __, status] = yield self.helper.wait_for_dispatched_statuses()
-        self.assertEqual(status['status'], 'ok')
-        self.assertEqual(status['component'], 'telegram_webhook')
-        self.assertEqual(status['type'], 'webhook_setup_success')
-        self.assertEqual(status['message'], 'Webhook setup successful')
-        self.assertEqual(status['details'], {'webhook_url': 'www.example.com'})
+        self.assert_status(status, {
+            'status': 'ok',
+            'component': 'telegram_webhook',
+            'type': 'webhook_setup_success',
+            'message': 'Webhook setup successful',
+            'details': {'webhook_url': 'www.example.com'},
+        })
 
     @inlineCallbacks
     def test_setup_webhook_with_errors(self):
@@ -156,12 +160,13 @@ class TestTelegramTransport(VumiTestCase):
 
         # Ignore statuses published on transport startup
         [_, __, status] = yield self.helper.wait_for_dispatched_statuses()
-        self.assertEqual(status['status'], 'down')
-        self.assertEqual(status['component'], 'telegram_webhook')
-        self.assertEqual(status['type'], 'bad_response')
-        self.assertEqual(status['message'],
-                         'Webhook setup failed: bad response from Telegram')
-        self.assertEqual(status['details'], {'error': error, 'res_code': 400})
+        self.assert_status(status, {
+            'status': 'down',
+            'component': 'telegram_webhook',
+            'type': 'bad_response',
+            'message': 'Webhook setup failed: bad response from Telegram',
+            'details': {'error': error, 'res_code': 400},
+        })
 
     @inlineCallbacks
     def test_setup_webhook_with_invalid_token(self):
@@ -187,14 +192,12 @@ class TestTelegramTransport(VumiTestCase):
         # Ignore statuses published on transport startup (only one, since
         # during tests this status is already published and doesn't repeat)
         [_, status] = yield self.helper.wait_for_dispatched_statuses()
-        self.assertEqual(status['status'], 'down')
-        self.assertEqual(status['component'], 'telegram_webhook')
-        self.assertEqual(status['type'], 'request_redirected')
-        self.assertEqual(status['message'],
-                         'Webhook setup failed: request redirected')
-        self.assertEqual(status['details'], {
-            'error': 'Unexpected redirect',
-            'res_code': 302,
+        self.assert_status(status, {
+            'status': 'down',
+            'component': 'telegram_webhook',
+            'type': 'request_redirected',
+            'message': 'Webhook setup failed: request redirected',
+            'details': {'error': 'Unexpected redirect', 'res_code': 302},
         })
 
     @inlineCallbacks
@@ -220,11 +223,12 @@ class TestTelegramTransport(VumiTestCase):
 
         # Ignore statuses published on transport startup
         [_, __, status] = yield self.helper.wait_for_dispatched_statuses()
-        self.assertEqual(status['status'], 'down')
-        self.assertEqual(status['component'], 'telegram_webhook')
-        self.assertEqual(status['type'], 'unexpected_response_format')
-        self.assertEqual(status['message'],
-                         'Webhook setup failed: unexpected response format')
+        self.assert_status(status, {
+            'status': 'down',
+            'component': 'telegram_webhook',
+            'type': 'unexpected_response_format',
+            'message': 'Webhook setup failed: unexpected response format',
+        })
         self.assertEqual(status['details']['res_code'], 500)
         self.assertEqual(status['details']['res_body'],
                          "Wait, this isn't JSON...")
@@ -303,10 +307,12 @@ class TestTelegramTransport(VumiTestCase):
 
         # Ignore statuses published on transport startup
         [_, __, status] = yield self.helper.wait_for_dispatched_statuses()
-        self.assertEqual(status['status'], 'ok')
-        self.assertEqual(status['component'], 'telegram_inbound')
-        self.assertEqual(status['type'], 'good_inbound')
-        self.assertEqual(status['message'], 'Good inbound request')
+        self.assert_status(status, {
+            'status': 'ok',
+            'component': 'telegram_inbound',
+            'type': 'good_inbound',
+            'message': 'Good inbound request',
+        })
 
         [msg] = yield self.helper.wait_for_dispatched_inbound(1)
         self.assertEqual(msg['to_addr'], self.bot_username)
@@ -344,10 +350,12 @@ class TestTelegramTransport(VumiTestCase):
 
         # Ignore statuses published on transport startup
         [_, __, status] = yield self.helper.wait_for_dispatched_statuses()
-        self.assertEqual(status['status'], 'ok')
-        self.assertEqual(status['component'], 'telegram_inbound')
-        self.assertEqual(status['type'], 'good_inbound')
-        self.assertEqual(status['message'], 'Good inbound request')
+        self.assert_status(status, {
+            'status': 'ok',
+            'component': 'telegram_inbound',
+            'type': 'good_inbound',
+            'message': 'Good inbound request',
+        })
 
         [msg] = yield self.helper.wait_for_dispatched_inbound(1)
         self.assertEqual(msg['content'], None)
@@ -416,11 +424,12 @@ class TestTelegramTransport(VumiTestCase):
 
         # Ignore statuses published on transport startup
         [_, __, status] = yield self.helper.wait_for_dispatched_statuses()
-        self.assertEqual(status['status'], 'down')
-        self.assertEqual(status['component'], 'telegram_inbound')
-        self.assertEqual(status['type'], 'unexpected_update_format')
-        self.assertEqual(status['message'],
-                         'Inbound update in unexpected format')
+        self.assert_status(status, {
+            'status': 'down',
+            'component': 'telegram_inbound',
+            'type': 'unexpected_update_format',
+            'message': 'Inbound update in unexpected format',
+        })
         self.assertEqual(status['details']['req_content'], "This isn't JSON!")
 
     @inlineCallbacks
@@ -469,10 +478,12 @@ class TestTelegramTransport(VumiTestCase):
 
         # Ignore statuses published on transport startup
         [_, __, status] = yield self.helper.wait_for_dispatched_statuses()
-        self.assertEqual(status['status'], 'ok')
-        self.assertEqual(status['component'], 'telegram_outbound')
-        self.assertEqual(status['type'], 'good_outbound_request')
-        self.assertEqual(status['message'], 'Outbound request successful')
+        self.assert_status(status, {
+            'status': 'ok',
+            'component': 'telegram_outbound',
+            'type': 'good_outbound_request',
+            'message': 'Outbound request successful',
+        })
 
     @inlineCallbacks
     def test_outbound_message_no_errors(self):
@@ -506,10 +517,12 @@ class TestTelegramTransport(VumiTestCase):
 
         # Ignore statuses published on transport startup
         [_, __, status] = yield self.helper.wait_for_dispatched_statuses()
-        self.assertEqual(status['status'], 'ok')
-        self.assertEqual(status['component'], 'telegram_outbound')
-        self.assertEqual(status['type'], 'good_outbound_request')
-        self.assertEqual(status['message'], 'Outbound request successful')
+        self.assert_status(status, {
+            'status': 'ok',
+            'component': 'telegram_outbound',
+            'type': 'good_outbound_request',
+            'message': 'Outbound request successful',
+        })
 
     @inlineCallbacks
     def test_outbound_message_with_errors(self):
@@ -535,14 +548,15 @@ class TestTelegramTransport(VumiTestCase):
 
         # Ignore statuses published on transport startup
         [_, __, status] = yield self.helper.wait_for_dispatched_statuses()
-        self.assertEqual(status['status'], 'down')
-        self.assertEqual(status['component'], 'telegram_outbound')
-        self.assertEqual(status['type'], 'bad_response')
-        self.assertEqual(status['message'],
-                         'Message not sent: bad response from Telegram')
-        self.assertEqual(status['details'], {
-            'error': self.bad_telegram_response['description'],
-            'res_code': 400,
+        self.assert_status(status, {
+            'status': 'down',
+            'component': 'telegram_outbound',
+            'type': 'bad_response',
+            'message': 'Message not sent: bad response from Telegram',
+            'details': {
+                'error': self.bad_telegram_response['description'],
+                'res_code': 400,
+            },
         })
 
     @inlineCallbacks
@@ -569,11 +583,12 @@ class TestTelegramTransport(VumiTestCase):
 
         # Ignore statuses published on transport startup
         [_, __, status] = yield self.helper.wait_for_dispatched_statuses()
-        self.assertEqual(status['status'], 'down')
-        self.assertEqual(status['component'], 'telegram_outbound')
-        self.assertEqual(status['type'], 'unexpected_response_format')
-        self.assertEqual(status['message'],
-                         'Message not sent: unexpected response format')
+        self.assert_status(status, {
+            'status': 'down',
+            'component': 'telegram_outbound',
+            'type': 'unexpected_response_format',
+            'message': 'Message not sent: unexpected response format',
+        })
         self.assertEqual(status['details']['res_code'], 500)
         self.assertEqual(status['details']['res_body'],
                          "Wait, this isn't JSON...")
@@ -602,14 +617,12 @@ class TestTelegramTransport(VumiTestCase):
 
         # Ignore statuses published on transport startup
         [_, __, status] = yield self.helper.wait_for_dispatched_statuses()
-        self.assertEqual(status['status'], 'down')
-        self.assertEqual(status['component'], 'telegram_outbound')
-        self.assertEqual(status['type'], 'request_redirected')
-        self.assertEqual(status['message'],
-                         'Message not sent: request redirected')
-        self.assertEqual(status['details'], {
-            'error': 'Unexpected redirect',
-            'res_code': 302,
+        self.assert_status(status, {
+            'status': 'down',
+            'component': 'telegram_outbound',
+            'type': 'request_redirected',
+            'message': 'Message not sent: request redirected',
+            'details': {'error': 'Unexpected redirect', 'res_code': 302},
         })
 
     @inlineCallbacks
@@ -629,11 +642,13 @@ class TestTelegramTransport(VumiTestCase):
 
         # Ignore statuses published on transport startup
         [_, __, status] = yield self.helper.wait_for_dispatched_statuses()
-        self.assertEqual(status['status'], 'down')
-        self.assertEqual(status['component'], 'telegram_outbound')
-        self.assertEqual(status['type'], 'test')
-        self.assertEqual(status['message'], 'Some kind of error')
-        self.assertEqual(status['details']['error'], error)
+        self.assert_status(status, {
+            'status': 'down',
+            'component': 'telegram_outbound',
+            'type': 'test',
+            'message': 'Some kind of error',
+            'details': {'error': error},
+        })
 
     @inlineCallbacks
     def test_outbound_success(self):
@@ -647,10 +662,19 @@ class TestTelegramTransport(VumiTestCase):
 
         # Ignore statuses published on transport startup
         [_, __, status] = yield self.helper.wait_for_dispatched_statuses()
-        self.assertEqual(status['status'], 'ok')
-        self.assertEqual(status['component'], 'telegram_outbound')
-        self.assertEqual(status['type'], 'good_outbound_request')
-        self.assertEqual(status['message'], 'Outbound request successful')
+        self.assert_status(status, {
+            'status': 'ok',
+            'component': 'telegram_outbound',
+            'type': 'good_outbound_request',
+            'message': 'Outbound request successful'
+        })
+
+    def assert_status(self, status, expected_fields):
+        """
+        Helper method for asserting that statuses are published correctly
+        """
+        for key in expected_fields.keys():
+            self.assertEqual(status[key], expected_fields[key])
 
     @inlineCallbacks
     def assert_nack(self, message_id, reason):


### PR DESCRIPTION
https://core.telegram.org/bots/api#inline-mode

Telegram allows users to send inline queries to bots by typing '@botusername query' in the message field without pressing send. These are sent to our webhook as updates with an `inline_query` field (if they press send, we receive them as ordinary messages). The transport should probably accept these and publish them as messages with a content of `None`, and the query in the `helper_metadata` dict. 

In addition, the transport should be able to send replies to these queries as an `inlineQueryResult` using Telegram's `answerInlineQuery` method, so that Telegram handles them correctly.
