### PR TITLE
Support direct replies

### DIFF
--- a/vxtelegram/telegram.py
+++ b/vxtelegram/telegram.py
@@ -196,6 +196,9 @@ class TelegramTransport(HttpRpcTransport):
             from_addr=message['from_addr'],
             transport_type=self.transport_type,
             transport_name=self.transport_name,
+            transport_metadata={
+                'telegram_id': message['telegram_id'],
+            }
         )
         request.finish()
 
@@ -212,6 +215,7 @@ class TelegramTransport(HttpRpcTransport):
         """
         Translates inbound Telegram message into Vumi's preferred format
         """
+        telegram_id = message['message_id']
         content = message['text']
         to_addr = self.bot_username
 
@@ -223,6 +227,7 @@ class TelegramTransport(HttpRpcTransport):
             from_addr = message['chat']['id']
 
         return {
+            'telegram_id': telegram_id,
             'content': content,
             'to_addr': to_addr,
             'from_addr': from_addr,
@@ -230,12 +235,17 @@ class TelegramTransport(HttpRpcTransport):
 
     @inlineCallbacks
     def handle_outbound_message(self, message):
-        # TODO: handle direct replies
         message_id = message['message_id']
         outbound_msg = {
             'chat_id': message['to_addr'],
             'text': message['content'],
         }
+
+        # Handle direct replies
+        if message['in_reply_to'] is not None:
+            reply_to_message = message['transport_metadata']['telegram_id']
+            outbound_msg.update({'reply_to_message': reply_to_message})
+
         url = self.get_outbound_url('sendMessage')
         http_client = HTTPClient(self.agent_factory())
 


### PR DESCRIPTION
Telegram supports the ability to reply to specific messages (as opposed to simply sending a message to the same chat as the original user's message) by specifying a `reply_to_message` parameter. This param should be the _Telegram_ `message_id` of the original message. We'd need to have a way to match a Vumi message's `in_reply_to` field with a Telegram `message_id` in order to do this.
