### PR TITLE
Prevent processing of duplicate updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 language: python
 python:
   - "2.7"
+services:
+  - redis-server
 matrix:
   include:
     - python: "pypy"

--- a/vxtelegram/telegram.py
+++ b/vxtelegram/telegram.py
@@ -214,8 +214,7 @@ class TelegramTransport(HttpRpcTransport):
         """
         config = self.get_static_config()
         key = self.get_update_id_key(update_id)
-        yield self.redis.set(key, 1)
-        yield self.redis.expire(key, config.update_lifetime)
+        yield self.redis.setex(key, 1, config.update_lifetime)
 
     def add_status_bad_inbound(self, status_type, message, details):
         return self.add_status(

--- a/vxtelegram/telegram.py
+++ b/vxtelegram/telegram.py
@@ -9,7 +9,7 @@ from twisted.web.client import Agent
 
 from vumi.transports.httprpc.httprpc import HttpRpcTransport
 from vumi.persist.txredis_manager import TxRedisManager
-from vumi.config import ConfigText, ConfigUrl, ConfigDict, ConfigInt
+from vumi.config import ConfigText, ConfigUrl, ConfigDict, ConfigFloat
 
 
 class TelegramTransportConfig(HttpRpcTransport.CONFIG_CLASS):
@@ -33,11 +33,11 @@ class TelegramTransportConfig(HttpRpcTransport.CONFIG_CLASS):
         'Parameters to connect to Redis with', default={}, static=True,
         required=False,
     )
-    update_lifetime = ConfigInt(
+    update_lifetime = ConfigFloat(
         'Time to store updates for to ensure we are not receiving dupllicates',
         # Defaults to 24 hours, since that is how long Telegram stores updates
         # on their servers
-        default=(60 * 60 * 24), static=True, required=False,
+        default=(60 * 60 * 24.0), static=True, required=False,
     )
 
 

--- a/vxtelegram/telegram.py
+++ b/vxtelegram/telegram.py
@@ -210,9 +210,8 @@ class TelegramTransport(HttpRpcTransport):
         Adds an update_id to a list of update_ids already processed
         """
         config = self.get_static_config()
-        lifetime = config.update_lifetime
-        yield self.redis.setnx(update_id, 1)
-        yield self.redis.expire(update_id, lifetime)
+        yield self.redis.set(update_id, 1)
+        yield self.redis.expire(update_id, config.update_lifetime)
 
     def add_status_bad_inbound(self, status_type, message, details):
         return self.add_status(

--- a/vxtelegram/telegram.py
+++ b/vxtelegram/telegram.py
@@ -9,7 +9,7 @@ from twisted.web.client import Agent
 
 from vumi.transports.httprpc.httprpc import HttpRpcTransport
 from vumi.persist.txredis_manager import TxRedisManager
-from vumi.config import ConfigText, ConfigUrl, ConfigDict, ConfigFloat
+from vumi.config import ConfigText, ConfigUrl, ConfigDict, ConfigInt
 
 
 class TelegramTransportConfig(HttpRpcTransport.CONFIG_CLASS):
@@ -33,11 +33,11 @@ class TelegramTransportConfig(HttpRpcTransport.CONFIG_CLASS):
         'Parameters to connect to Redis with', default={}, static=True,
         required=False,
     )
-    update_lifetime = ConfigFloat(
+    update_lifetime = ConfigInt(
         'Time to store updates for to ensure we are not receiving dupllicates',
         # Defaults to 24 hours, since that is how long Telegram stores updates
         # on their servers
-        default=(60 * 60 * 24.0), static=True, required=False,
+        default=(60 * 60 * 24), static=True, required=False,
     )
 
 

--- a/vxtelegram/telegram.py
+++ b/vxtelegram/telegram.py
@@ -196,12 +196,15 @@ class TelegramTransport(HttpRpcTransport):
         )
         request.finish()
 
+    def get_update_id_key(self, update_id):
+        return 'update_id:%s' % update_id
+
     @inlineCallbacks
     def is_duplicate(self, update_id):
         """
         Checks to see if an incoming update has already been processed
         """
-        exists = yield self.redis.exists(update_id)
+        exists = yield self.redis.exists(self.get_update_id_key(update_id))
         returnValue(exists)
 
     @inlineCallbacks
@@ -210,8 +213,9 @@ class TelegramTransport(HttpRpcTransport):
         Adds an update_id to a list of update_ids already processed
         """
         config = self.get_static_config()
-        yield self.redis.set(update_id, 1)
-        yield self.redis.expire(update_id, config.update_lifetime)
+        key = self.get_update_id_key(update_id)
+        yield self.redis.set(key, 1)
+        yield self.redis.expire(key, config.update_lifetime)
 
     def add_status_bad_inbound(self, status_type, message, details):
         return self.add_status(

--- a/vxtelegram/tests/test_telegram.py
+++ b/vxtelegram/tests/test_telegram.py
@@ -287,7 +287,7 @@ class TestTelegramTransport(VumiTestCase):
         duplicate = yield transport.is_duplicate(1234)
         self.assertTrue(duplicate)
         ttl = yield transport.redis.ttl(1234)
-        self.assertTrue(ttl < 10)
+        self.assertTrue(ttl <= 10)
 
     @inlineCallbacks
     def test_duplicate_update(self):

--- a/vxtelegram/tests/test_telegram.py
+++ b/vxtelegram/tests/test_telegram.py
@@ -283,7 +283,7 @@ class TestTelegramTransport(VumiTestCase):
         """
         # This test is very pedantic about the value used for update_lifetime,
         # as well as how long the thread should sleep - change at your own risk
-        transport = yield self.get_transport(update_lifetime=0.2)
+        transport = yield self.get_transport(update_lifetime=1)
         yield transport.mark_as_seen(1234)
         a = yield transport.is_duplicate(1234)
         self.assertTrue(a)

--- a/vxtelegram/tests/test_telegram.py
+++ b/vxtelegram/tests/test_telegram.py
@@ -281,7 +281,9 @@ class TestTelegramTransport(VumiTestCase):
         update_ids in Redis should expire after update_lifetime has elapsed,
         meaning they should no longer be considered duplicates
         """
-        transport = yield self.get_transport(update_lifetime=1)
+        # This test is very pedantic about the value used for update_lifetime,
+        # as well as how long the thread should sleep - change at your own risk
+        transport = yield self.get_transport(update_lifetime=0.2)
         yield transport.mark_as_seen('update_id')
         a = yield transport.is_duplicate('update_id')
         self.assertTrue(a)
@@ -297,7 +299,7 @@ class TestTelegramTransport(VumiTestCase):
         """
         We should log receipt of duplicate updates and discard them
         """
-        yield self.get_transport(update_lifetime=1)
+        yield self.get_transport()
         update = {
             'update_id': 'first_id',
         }

--- a/vxtelegram/tests/test_telegram.py
+++ b/vxtelegram/tests/test_telegram.py
@@ -284,14 +284,14 @@ class TestTelegramTransport(VumiTestCase):
         # This test is very pedantic about the value used for update_lifetime,
         # as well as how long the thread should sleep - change at your own risk
         transport = yield self.get_transport(update_lifetime=0.2)
-        yield transport.mark_as_seen('update_id')
-        a = yield transport.is_duplicate('update_id')
+        yield transport.mark_as_seen(1234)
+        a = yield transport.is_duplicate(1234)
         self.assertTrue(a)
 
         # Wait for update_id to expire
         from time import sleep
         sleep(2)
-        b = yield transport.is_duplicate('update_id')
+        b = yield transport.is_duplicate(1234)
         self.assertFalse(b)
 
     @inlineCallbacks
@@ -301,7 +301,7 @@ class TestTelegramTransport(VumiTestCase):
         """
         yield self.get_transport()
         update = {
-            'update_id': 'first_id',
+            'update_id': 1234,
         }
 
         # Make initial request
@@ -317,7 +317,7 @@ class TestTelegramTransport(VumiTestCase):
         with LogCatcher(message='duplicate') as lc:
             res = yield d
             [log] = lc.messages()
-            self.assertEqual(log, 'Received a duplicate update: first_id')
+            self.assertEqual(log, 'Received a duplicate update: 1234')
         self.assertEqual(res.code, http.OK)
 
     @inlineCallbacks
@@ -328,7 +328,7 @@ class TestTelegramTransport(VumiTestCase):
         """
         transport = yield self.get_transport(publish_status=True)
         update = {
-            'update_id': 'update_id',
+            'update_id': 1234,
             'message': {
                 'message_id': 'msg_id',
                 'from': self.default_user,
@@ -381,7 +381,7 @@ class TestTelegramTransport(VumiTestCase):
             (self.default_user['id'], self.bot_username)
         )
         update = {
-            'update_id': 'update_id',
+            'update_id': 1234,
             'inline_query': {
                 'id': "1234",
                 'from': self.default_user,
@@ -429,7 +429,7 @@ class TestTelegramTransport(VumiTestCase):
         """
         yield self.get_transport()
         update = json.dumps({
-            'update_id': 'update_id',
+            'update_id': 1234,
             'object': 'This is not a message...',
         })
         d = self.helper.mk_request(_method='POST', _data=update)
@@ -447,7 +447,7 @@ class TestTelegramTransport(VumiTestCase):
         """
         yield self.get_transport()
         update = json.dumps({
-            'update_id': 'update_id',
+            'update_id': 1234,
             'message': {
                 'message_id': 'msg_id',
                 'object': 'This is not a text message...'


### PR DESCRIPTION
Telegram's API  docs warn of the possibility of sending duplicate updates to our webhook URL. Each update contains a unique `update_id` field - we should implement a way to store these and check that each update we receive has not already been processed.
