### PR TITLE
Publish down status when outbound inline queries fail

### DIFF
--- a/vxtelegram/telegram.py
+++ b/vxtelegram/telegram.py
@@ -348,6 +348,20 @@ class TelegramTransport(HttpRpcTransport):
                 message_id,
                 'Query reply not sent: results field not present',
             )
+            self.add_status(
+                status='down',
+                component='telegram_query_reply',
+                type='bad_query_reply',
+                message='Query reply not sent: results field not present',
+                details={
+                    'error': "Transport received an outbound query reply that "
+                             "did not contain any results. Check that your "
+                             "application is configured to reply to inline "
+                             "queries. If you're not supporting inline "
+                             "queries, you should disable your bot's inline "
+                             "mode.",
+                },
+            )
             return
 
         r = yield http_client.post(

--- a/vxtelegram/telegram.py
+++ b/vxtelegram/telegram.py
@@ -374,6 +374,12 @@ class TelegramTransport(HttpRpcTransport):
         validate = yield self.validate_outbound(r)
         if validate['success']:
             yield self.outbound_success(message_id)
+            self.add_status(
+                status='ok',
+                component='telegram_query_reply',
+                type='good_query_reply',
+                message='Outbound request successful',
+            )
         else:
             validate['details'].update({'inline_query_id': inline_query_id})
             yield self.outbound_failure(

--- a/vxtelegram/tests/test_telegram.py
+++ b/vxtelegram/tests/test_telegram.py
@@ -533,11 +533,17 @@ class TestTelegramTransport(VumiTestCase):
         self.assert_ack(msg['message_id'])
 
         # Ignore statuses published on transport startup
-        [_, __, status] = yield self.helper.wait_for_dispatched_statuses()
-        self.assert_dict(status, {
+        [_, __, out, query] = yield self.helper.wait_for_dispatched_statuses()
+        self.assert_dict(out, {
             'status': 'ok',
             'component': 'telegram_outbound',
             'type': 'good_outbound_request',
+            'message': 'Outbound request successful',
+        })
+        self.assert_dict(query, {
+            'status': 'ok',
+            'component': 'telegram_query_reply',
+            'type': 'good_query_reply',
             'message': 'Outbound request successful',
         })
 

--- a/vxtelegram/tests/test_telegram.py
+++ b/vxtelegram/tests/test_telegram.py
@@ -544,11 +544,10 @@ class TestTelegramTransport(VumiTestCase):
     @inlineCallbacks
     def test_outbound_query_reply_unexpected_format(self):
         """
-        We should log and publish a nack when a query reply does not contain a
-        results field. We don't publish a down status, since this
-        event has no bearing on the transport's health.
+        We should log and publish a nack / 'down' status when a query reply
+        does not contain a results field.
         """
-        yield self.get_transport()
+        yield self.get_transport(publish_status=True)
         expected_log = 'Query reply not sent: results field not present'
         msg = self.helper.make_outbound(
             content=None,
@@ -567,6 +566,20 @@ class TestTelegramTransport(VumiTestCase):
             [log] = lc.messages()
             self.assertEqual(log, expected_log)
             self.assert_nack(msg['message_id'], expected_log)
+
+        # Ignore statuses published on transport startup
+        [_, __, status] = yield self.helper.wait_for_dispatched_statuses()
+        self.assert_dict(status, {
+            'status': 'down',
+            'component': 'telegram_query_reply',
+            'type': 'bad_query_reply',
+            'message': 'Query reply not sent: results field not present',
+        })
+        # We assert this field separately as a substring because it is verbose
+        self.assertSubstring(
+            "you should disable your bot's inline mode",
+            status['details']['error']
+        )
 
     @inlineCallbacks
     def test_outbound_query_reply_with_errors(self):


### PR DESCRIPTION
We've seen to it that the transport doesn't break when it receives a reply to an inline query (from an application) that doesn't contain a results field. Most likely this would be because

a)  The bot is operating in inline mode when it is not meant to be.
b)  The application is not configured to reply to inline queries (it is probably not Telegram-specific).

Either way, this is something the user should be informed of. We should publish a 'down' status in a separate component (so that the overall transport health is not misrepresented) informing the user that they should probably change their setup configuration - either disable inline mode, or enable the application to support it.
