### PR TITLE
Use Telegram usernames in 'to_addr' and 'from_addr'

### DIFF
--- a/vxtelegram/telegram.py
+++ b/vxtelegram/telegram.py
@@ -49,6 +49,11 @@ class TelegramTransport(HttpRpcTransport):
 
     CONFIG_CLASS = TelegramTransportConfig
 
+    # Telegram usernames are human-readable strings that identify users
+    TELEGRAM_USERNAME = 'telegram_username'
+    # Telegram ids are integers that identify users in the Telegram API
+    TELEGRAM_ID = 'telegram_id'
+
     @classmethod
     def agent_factory(cls):
         """
@@ -177,7 +182,7 @@ class TelegramTransport(HttpRpcTransport):
             message_id=message_id,
             content=message['content'],
             to_addr=message['to_addr'],
-            to_addr_type='telegram_username',
+            to_addr_type=self.TELEGRAM_USERNAME,
             from_addr=message['from_addr'],
             from_addr_type=message['from_addr_type'],
             transport_type=self.transport_type,
@@ -241,9 +246,9 @@ class TelegramTransport(HttpRpcTransport):
             message_id=message_id,
             content=inline_query['query'],
             to_addr=self.bot_username,
-            to_addr_type='telegram_username',
+            to_addr_type=self.TELEGRAM_USERNAME,
             from_addr=inline_query['from']['username'],
-            from_addr_type='telegram_username',
+            from_addr_type=self.TELEGRAM_USERNAME,
             transport_type=self.transport_type,
             transport_name=self.transport_name,
             helper_metadata={
@@ -279,11 +284,11 @@ class TelegramTransport(HttpRpcTransport):
         # case, we want the channel's chat id
         if 'from' in message:
             from_addr = message['from']['username']
-            from_addr_type = 'telegram_username'
+            from_addr_type = self.TELEGRAM_USERNAME
             telegram_user_id = message['from']['id']
         else:
             from_addr = message['chat']['id']
-            from_addr_type = 'telegram_id'
+            from_addr_type = self.TELEGRAM_ID
             telegram_user_id = from_addr
 
         return {

--- a/vxtelegram/telegram.py
+++ b/vxtelegram/telegram.py
@@ -179,10 +179,13 @@ class TelegramTransport(HttpRpcTransport):
             to_addr=message['to_addr'],
             to_addr_type='telegram_username',
             from_addr=message['from_addr'],
-            from_addr_type='telegram_id',
+            from_addr_type=message['from_addr_type'],
             transport_type=self.transport_type,
             transport_name=self.transport_name,
-            transport_metadata={'telegram_id': message['telegram_id']},
+            transport_metadata={
+                'telegram_msg_id': message['telegram_msg_id'],
+                'telegram_user_id': message['telegram_user_id'],
+            },
         )
 
         yield self.add_status(
@@ -232,15 +235,15 @@ class TelegramTransport(HttpRpcTransport):
         #       see: https://core.telegram.org/bots/api#answerinlinequery
         self.log.info(
             'TelegramTransport receiving inline query from %s to %s' % (
-                inline_query['from']['id'], self.bot_username))
+                inline_query['from']['username'], self.bot_username))
 
         yield self.publish_message(
             message_id=message_id,
             content=inline_query['query'],
             to_addr=self.bot_username,
             to_addr_type='telegram_username',
-            from_addr=inline_query['from']['id'],
-            from_addr_type='telegram_id',
+            from_addr=inline_query['from']['username'],
+            from_addr_type='telegram_username',
             transport_type=self.transport_type,
             transport_name=self.transport_name,
             helper_metadata={
@@ -251,7 +254,8 @@ class TelegramTransport(HttpRpcTransport):
             },
             transport_metadata={
                 'type': 'inline_query',
-                'details': {'query_id': inline_query['id']},
+                'details': {'inline_query_id': inline_query['id']},
+                'telegram_user_id': inline_query['from']['id']
             },
         )
 
@@ -264,24 +268,31 @@ class TelegramTransport(HttpRpcTransport):
 
     def translate_inbound_message(self, message):
         """
-        Translates inbound Telegram message into Vumi's default format.
+        Translates inbound Telegram message into Vumi's default format. We want
+        to use the user's username as from_addr if possible, for readability.
         """
-        telegram_id = message['message_id']
+        telegram_msg_id = message['message_id']
         content = message['text']
         to_addr = self.bot_username
 
         # Messages sent over channels do not contain a 'from' field - in that
         # case, we want the channel's chat id
         if 'from' in message:
-            from_addr = message['from']['id']
+            from_addr = message['from']['username']
+            from_addr_type = 'telegram_username'
+            telegram_user_id = message['from']['id']
         else:
             from_addr = message['chat']['id']
+            from_addr_type = 'telegram_id'
+            telegram_user_id = from_addr
 
         return {
-            'telegram_id': telegram_id,
+            'telegram_msg_id': telegram_msg_id,
             'content': content,
             'to_addr': to_addr,
             'from_addr': from_addr,
+            'from_addr_type': from_addr_type,
+            'telegram_user_id': telegram_user_id,
         }
 
     @inlineCallbacks
@@ -294,13 +305,13 @@ class TelegramTransport(HttpRpcTransport):
             return
 
         outbound_msg = {
-            'chat_id': message['to_addr'],
+            'chat_id': message['transport_metadata']['telegram_user_id'],
             'text': message['content'],
         }
 
         # Handle direct replies
         if message['in_reply_to'] is not None:
-            reply_to_message = message['transport_metadata']['telegram_id']
+            reply_to_message = message['transport_metadata']['telegram_msg_id']
             outbound_msg.update({'reply_to_message': reply_to_message})
 
         url = self.get_outbound_url('sendMessage')
@@ -333,11 +344,11 @@ class TelegramTransport(HttpRpcTransport):
         url = self.get_outbound_url('answerInlineQuery')
         http_client = HTTPClient(self.agent_factory())
 
-        inline_query_id = message['transport_metadata']['details']['query_id']
+        query_id = message['transport_metadata']['details']['inline_query_id']
 
         try:
             outbound_query_answer = {
-                'inline_query_id': inline_query_id,
+                'inline_query_id': query_id,
                 'results': message['helper_metadata']['telegram']['results'],
             }
 
@@ -361,7 +372,7 @@ class TelegramTransport(HttpRpcTransport):
         if validate['success']:
             yield self.outbound_success(message_id)
         else:
-            validate['details'].update({'inline_query_id': inline_query_id})
+            validate['details'].update({'inline_query_id': query_id})
             yield self.outbound_failure(
                 message_id=message_id,
                 message='Query reply not sent: %s' % validate['message'],

--- a/vxtelegram/telegram.py
+++ b/vxtelegram/telegram.py
@@ -249,13 +249,13 @@ class TelegramTransport(HttpRpcTransport):
             helper_metadata={
                 'telegram': {
                     'type': 'inline_query',
-                    'details': {'inline_query_id': inline_query['id']}
-                }
+                    'details': {'inline_query_id': inline_query['id']},
+                },
             },
             transport_metadata={
                 'type': 'inline_query',
                 'details': {'inline_query_id': inline_query['id']},
-                'telegram_user_id': inline_query['from']['id']
+                'telegram_user_id': inline_query['from']['id'],
             },
         )
 

--- a/vxtelegram/tests/test_telegram.py
+++ b/vxtelegram/tests/test_telegram.py
@@ -51,7 +51,7 @@ class TestTelegramTransport(VumiTestCase):
             'web_path': 'foo',
             'web_port': 0,
             'inbound_url': 'www.example.com',
-            'outbound_url': self.API_URL
+            'outbound_url': self.API_URL,
         }
         defaults.update(config)
         transport = yield self.helper.get_transport(defaults)
@@ -155,7 +155,7 @@ class TestTelegramTransport(VumiTestCase):
             [log] = lc.messages()
             self.assertEqual(
                 log,
-                'Webhook setup failed: bad response from Telegram'
+                'Webhook setup failed: bad response from Telegram',
             )
 
         # Ignore statuses published on transport startup
@@ -186,7 +186,7 @@ class TestTelegramTransport(VumiTestCase):
             [log] = lc.messages()
             self.assertEqual(
                 log,
-                'Webhook setup failed: request redirected'
+                'Webhook setup failed: request redirected',
             )
 
         # Ignore statuses published on transport startup (only one, since
@@ -457,7 +457,7 @@ class TestTelegramTransport(VumiTestCase):
             'update_id': 1234,
             'message': {
                 'message_id': 5678,
-                'object': 'This is not a text message...'
+                'object': 'This is not a text message...',
             },
         })
 
@@ -640,7 +640,7 @@ class TestTelegramTransport(VumiTestCase):
             to_addr=self.default_user['username'],
             to_addr_type='telegram_username',
             from_addr=self.bot_username,
-            transport_metadata={'telegram_user_id': self.default_user['id']}
+            transport_metadata={'telegram_user_id': self.default_user['id']},
         )
         d = self.helper.dispatch_outbound(msg)
 
@@ -700,7 +700,7 @@ class TestTelegramTransport(VumiTestCase):
         self.assert_dict(outbound_msg, {
             'text': msg['content'],
             'chat_id': msg['transport_metadata']['telegram_user_id'],
-            'reply_to_message': msg['transport_metadata']['telegram_msg_id']
+            'reply_to_message': msg['transport_metadata']['telegram_msg_id'],
         })
 
         req.write(json.dumps({'ok': True}))
@@ -824,7 +824,8 @@ class TestTelegramTransport(VumiTestCase):
             status_type='test',
             message_id='id',
             message='Some kind of error',
-            details={'error': error})
+            details={'error': error},
+        )
         yield self.assert_nack('id', 'Some kind of error')
 
         # Ignore statuses published on transport startup

--- a/vxtelegram/tests/test_telegram.py
+++ b/vxtelegram/tests/test_telegram.py
@@ -240,11 +240,11 @@ class TestTelegramTransport(VumiTestCase):
         """
         transport = yield self.get_transport()
         default_channel = {
-            'id': 'Default channel',
+            'id': 2468,
             'type': 'channel',
         }
         inbound_msg = {
-            'message_id': 'Message from Telegram channel',
+            'message_id': 1234,
             'chat': default_channel,
             'text': 'Hi from Telegram channel!',
         }
@@ -254,7 +254,9 @@ class TestTelegramTransport(VumiTestCase):
             'content': inbound_msg['text'],
             'to_addr': self.bot_username,
             'from_addr': default_channel['id'],
-            'telegram_id': inbound_msg['message_id'],
+            'from_addr_type': 'telegram_id',
+            'telegram_msg_id': inbound_msg['message_id'],
+            'telegram_user_id': default_channel['id'],
         })
 
     @inlineCallbacks
@@ -264,8 +266,8 @@ class TestTelegramTransport(VumiTestCase):
         """
         transport = yield self.get_transport()
         inbound_msg = {
-            'message_id': 'Message from Telegram user',
-            'chat': 'Random chat',
+            'message_id': 1234,
+            'chat': {},
             'text': 'Hi from Telegram user!',
             'from': self.default_user,
         }
@@ -274,8 +276,10 @@ class TestTelegramTransport(VumiTestCase):
         self.assert_dict(message, {
             'content': inbound_msg['text'],
             'to_addr': self.bot_username,
-            'from_addr': self.default_user['id'],
-            'telegram_id': inbound_msg['message_id'],
+            'from_addr': self.default_user['username'],
+            'from_addr_type': 'telegram_username',
+            'telegram_msg_id': inbound_msg['message_id'],
+            'telegram_user_id': self.default_user['id'],
         })
 
     @inlineCallbacks
@@ -325,7 +329,7 @@ class TestTelegramTransport(VumiTestCase):
         transport = yield self.get_transport(publish_status=True)
         expected_log = (
             'TelegramTransport receiving inbound message from %s to %s' %
-            (self.default_user['id'], self.bot_username)
+            (self.default_user['username'], self.bot_username)
         )
         update = {
             'update_id': 1234,
@@ -358,13 +362,14 @@ class TestTelegramTransport(VumiTestCase):
         self.assert_dict(msg, {
             'to_addr': self.bot_username,
             'to_addr_type': 'telegram_username',
-            'from_addr': self.default_user['id'],
-            'from_addr_type': 'telegram_id',
+            'from_addr': self.default_user['username'],
+            'from_addr_type': 'telegram_username',
             'content': update['message']['text'],
             'transport_type': transport.transport_type,
             'transport_name': transport.transport_name,
             'transport_metadata': {
-                'telegram_id': update['message']['message_id'],
+                'telegram_msg_id': update['message']['message_id'],
+                'telegram_user_id': self.default_user['id'],
             },
         })
 
@@ -377,7 +382,7 @@ class TestTelegramTransport(VumiTestCase):
         transport = yield self.get_transport(publish_status=True)
         expected_log = (
             'TelegramTransport receiving inline query from %s to %s' %
-            (self.default_user['id'], self.bot_username)
+            (self.default_user['username'], self.bot_username)
         )
         update = {
             'update_id': 1234,
@@ -409,8 +414,8 @@ class TestTelegramTransport(VumiTestCase):
             'content': update['inline_query']['query'],
             'to_addr': self.bot_username,
             'to_addr_type': 'telegram_username',
-            'from_addr': self.default_user['id'],
-            'from_addr_type': 'telegram_id',
+            'from_addr': self.default_user['username'],
+            'from_addr_type': 'telegram_username',
             'transport_type': transport.transport_type,
             'transport_name': transport.transport_name,
             'helper_metadata': {'telegram': {
@@ -419,7 +424,8 @@ class TestTelegramTransport(VumiTestCase):
             }},
             'transport_metadata': {
                 'type': 'inline_query',
-                'details': {'query_id': update['inline_query']['id']},
+                'details': {'inline_query_id': update['inline_query']['id']},
+                'telegram_user_id': self.default_user['id'],
             },
         })
 
@@ -506,11 +512,13 @@ class TestTelegramTransport(VumiTestCase):
         }]
         msg = self.helper.make_outbound(
             content=None,
-            to_addr=self.default_user['id'],
+            to_addr=self.default_user['username'],
+            from_addr_type='telegram_username',
             from_addr=self.bot_username,
             transport_metadata={
                 'type': 'inline_query',
-                'details': {'query_id': '1234'},
+                'details': {'inline_query_id': '1234'},
+                'telegram_user_id': self.default_user['id'],
             },
             helper_metadata={
                 'telegram': {'type': 'inline_query_reply', 'results': results},
@@ -552,11 +560,13 @@ class TestTelegramTransport(VumiTestCase):
         expected_log = 'Query reply not sent: results field not present'
         msg = self.helper.make_outbound(
             content=None,
-            to_addr=self.default_user['id'],
+            to_addr=self.default_user['username'],
+            to_addr_type='telegram_username',
             from_addr=self.bot_username,
             transport_metadata={
                 'type': 'inline_query',
-                'details': {'query_id': 'valid_id'},
+                'details': {'inline_query_id': 'valid_id'},
+                'telegram_user_id': self.default_user['id'],
             },
             helper_metadata={'telegram': {}},
         )
@@ -577,11 +587,13 @@ class TestTelegramTransport(VumiTestCase):
         yield self.get_transport(publish_status=True)
         msg = self.helper.make_outbound(
             content=None,
-            to_addr=self.default_user['id'],
+            to_addr=self.default_user['username'],
+            to_addr_type='telegram_username',
             from_addr=self.bot_username,
             transport_metadata={
                 'type': 'inline_query',
-                'details': {'query_id': 'invalid_id'},
+                'details': {'inline_query_id': 'invalid_id'},
+                'telegram_user_id': self.default_user['id'],
             },
             helper_metadata={
                 'telegram': {'type': 'inline_query_reply', 'results': []},
@@ -625,8 +637,10 @@ class TestTelegramTransport(VumiTestCase):
                                     'sendMessage')
         msg = self.helper.make_outbound(
             content='Outbound message!',
-            to_addr=self.default_user['id'],
+            to_addr=self.default_user['username'],
+            to_addr_type='telegram_username',
             from_addr=self.bot_username,
+            transport_metadata={'telegram_user_id': self.default_user['id']}
         )
         d = self.helper.dispatch_outbound(msg)
 
@@ -637,7 +651,7 @@ class TestTelegramTransport(VumiTestCase):
         outbound_msg = json.load(req.content)
         self.assert_dict(outbound_msg, {
             'text': msg['content'],
-            'chat_id': msg['to_addr'],
+            'chat_id': msg['transport_metadata']['telegram_user_id'],
         })
 
         req.write(json.dumps({'ok': True}))
@@ -667,10 +681,14 @@ class TestTelegramTransport(VumiTestCase):
                                     'sendMessage')
         msg = self.helper.make_outbound(
             content='Outbound reply!',
-            to_addr=self.default_user['id'],
+            to_addr=self.default_user['username'],
+            to_addr_type='telegram_username',
             from_addr=self.bot_username,
-            in_reply_to='original_message_id',
-            transport_metadata={'telegram_id': 1234}
+            in_reply_to=2468,
+            transport_metadata={
+                'telegram_msg_id': 1234,
+                'telegram_user_id': 36912,
+            },
         )
         d = self.helper.dispatch_outbound(msg)
 
@@ -681,8 +699,8 @@ class TestTelegramTransport(VumiTestCase):
         outbound_msg = json.load(req.content)
         self.assert_dict(outbound_msg, {
             'text': msg['content'],
-            'chat_id': msg['to_addr'],
-            'reply_to_message': msg['transport_metadata']['telegram_id']
+            'chat_id': msg['transport_metadata']['telegram_user_id'],
+            'reply_to_message': msg['transport_metadata']['telegram_msg_id']
         })
 
         req.write(json.dumps({'ok': True}))
@@ -700,7 +718,8 @@ class TestTelegramTransport(VumiTestCase):
         yield self.get_transport(publish_status=True)
         msg = yield self.helper.make_outbound(
             content='Outbound message!',
-            to_addr=self.default_user['id']
+            to_addr=self.default_user['username'],
+            transport_metadata={'telegram_user_id': 1234},
         )
         d = self.helper.dispatch_outbound(msg)
 
@@ -735,8 +754,9 @@ class TestTelegramTransport(VumiTestCase):
         yield self.get_transport(publish_status=True)
         msg = yield self.helper.make_outbound(
             content='Outbound message!',
-            to_addr=self.default_user['id']
-            )
+            to_addr=self.default_user['username'],
+            transport_metadata={'telegram_user_id': 1234},
+        )
         d = self.helper.dispatch_outbound(msg)
 
         req = yield self.get_next_request()
@@ -768,8 +788,9 @@ class TestTelegramTransport(VumiTestCase):
         yield self.get_transport(publish_status=True)
         msg = yield self.helper.make_outbound(
             content='Outbound message!',
-            to_addr=self.default_user['id'],
-            )
+            to_addr=self.default_user['username'],
+            transport_metadata={'telegram_user_id': 1234},
+        )
         d = self.helper.dispatch_outbound(msg)
 
         req = yield self.get_next_request()

--- a/vxtelegram/tests/test_telegram.py
+++ b/vxtelegram/tests/test_telegram.py
@@ -24,6 +24,11 @@ class TestTelegramTransport(VumiTestCase):
     CHANNEL = 'channel'
     GROUP = 'group'
 
+    # Telegram usernames are human-readable strings that identify users
+    TELEGRAM_USERNAME = 'telegram_username'
+    # Telegram ids are integers that identify users in the Telegram API
+    TELEGRAM_ID = 'telegram_id'
+
     # Some default Telegram objects
     default_user = {
         'id': 2468,
@@ -254,7 +259,7 @@ class TestTelegramTransport(VumiTestCase):
             'content': inbound_msg['text'],
             'to_addr': self.bot_username,
             'from_addr': default_channel['id'],
-            'from_addr_type': 'telegram_id',
+            'from_addr_type': self.TELEGRAM_ID,
             'telegram_msg_id': inbound_msg['message_id'],
             'telegram_user_id': default_channel['id'],
         })
@@ -277,7 +282,7 @@ class TestTelegramTransport(VumiTestCase):
             'content': inbound_msg['text'],
             'to_addr': self.bot_username,
             'from_addr': self.default_user['username'],
-            'from_addr_type': 'telegram_username',
+            'from_addr_type': self.TELEGRAM_USERNAME,
             'telegram_msg_id': inbound_msg['message_id'],
             'telegram_user_id': self.default_user['id'],
         })
@@ -361,9 +366,9 @@ class TestTelegramTransport(VumiTestCase):
         [msg] = yield self.helper.wait_for_dispatched_inbound(1)
         self.assert_dict(msg, {
             'to_addr': self.bot_username,
-            'to_addr_type': 'telegram_username',
+            'to_addr_type': self.TELEGRAM_USERNAME,
             'from_addr': self.default_user['username'],
-            'from_addr_type': 'telegram_username',
+            'from_addr_type': self.TELEGRAM_USERNAME,
             'content': update['message']['text'],
             'transport_type': transport.transport_type,
             'transport_name': transport.transport_name,
@@ -413,9 +418,9 @@ class TestTelegramTransport(VumiTestCase):
         self.assert_dict(msg, {
             'content': update['inline_query']['query'],
             'to_addr': self.bot_username,
-            'to_addr_type': 'telegram_username',
+            'to_addr_type': self.TELEGRAM_USERNAME,
             'from_addr': self.default_user['username'],
-            'from_addr_type': 'telegram_username',
+            'from_addr_type': self.TELEGRAM_USERNAME,
             'transport_type': transport.transport_type,
             'transport_name': transport.transport_name,
             'helper_metadata': {'telegram': {
@@ -513,7 +518,7 @@ class TestTelegramTransport(VumiTestCase):
         msg = self.helper.make_outbound(
             content=None,
             to_addr=self.default_user['username'],
-            from_addr_type='telegram_username',
+            from_addr_type=self.TELEGRAM_USERNAME,
             from_addr=self.bot_username,
             transport_metadata={
                 'type': 'inline_query',
@@ -566,7 +571,7 @@ class TestTelegramTransport(VumiTestCase):
         msg = self.helper.make_outbound(
             content=None,
             to_addr=self.default_user['username'],
-            to_addr_type='telegram_username',
+            to_addr_type=self.TELEGRAM_USERNAME,
             from_addr=self.bot_username,
             transport_metadata={
                 'type': 'inline_query',
@@ -607,7 +612,7 @@ class TestTelegramTransport(VumiTestCase):
         msg = self.helper.make_outbound(
             content=None,
             to_addr=self.default_user['username'],
-            to_addr_type='telegram_username',
+            to_addr_type=self.TELEGRAM_USERNAME,
             from_addr=self.bot_username,
             transport_metadata={
                 'type': 'inline_query',
@@ -657,7 +662,7 @@ class TestTelegramTransport(VumiTestCase):
         msg = self.helper.make_outbound(
             content='Outbound message!',
             to_addr=self.default_user['username'],
-            to_addr_type='telegram_username',
+            to_addr_type=self.TELEGRAM_USERNAME,
             from_addr=self.bot_username,
             transport_metadata={'telegram_user_id': self.default_user['id']},
         )
@@ -701,7 +706,7 @@ class TestTelegramTransport(VumiTestCase):
         msg = self.helper.make_outbound(
             content='Outbound reply!',
             to_addr=self.default_user['username'],
-            to_addr_type='telegram_username',
+            to_addr_type=self.TELEGRAM_USERNAME,
             from_addr=self.bot_username,
             in_reply_to=2468,
             transport_metadata={


### PR DESCRIPTION
Using Telegram `username`s in these fields would make logs, statuses etc. more human-readable. However, since the user's `id` is still necessary for making requests to Telegram's API, this would have to be included in the `transport_metadata`.
