### PR TITLE
Outbound messages not in correct format

### DIFF
--- a/vxtelegram/telegram.py
+++ b/vxtelegram/telegram.py
@@ -318,7 +318,7 @@ class TelegramTransport(HttpRpcTransport):
             return
 
         outbound_msg = {
-            'chat_id': message['transport_metadata']['telegram_user_id'],
+            'chat_id': message['to_addr'],
             'text': message['content'],
         }
 

--- a/vxtelegram/tests/test_telegram.py
+++ b/vxtelegram/tests/test_telegram.py
@@ -675,7 +675,7 @@ class TestTelegramTransport(VumiTestCase):
         outbound_msg = json.load(req.content)
         self.assert_dict(outbound_msg, {
             'text': msg['content'],
-            'chat_id': msg['transport_metadata']['telegram_user_id'],
+            'chat_id': msg['to_addr'],
         })
 
         req.write(json.dumps({'ok': True}))
@@ -723,7 +723,7 @@ class TestTelegramTransport(VumiTestCase):
         outbound_msg = json.load(req.content)
         self.assert_dict(outbound_msg, {
             'text': msg['content'],
-            'chat_id': msg['transport_metadata']['telegram_user_id'],
+            'chat_id': msg['to_addr'],
             'reply_to_message': msg['transport_metadata']['telegram_msg_id'],
         })
 


### PR DESCRIPTION
This one is my mistake. During the last PR, I forgot to change how `handle_outbound_message`, well, handles outbound messages. It still expects the messages to contain fields they no longer contain. Should hopefully be a quick fix.
