### PR TITLE
sendMessage parameter should be `reply_to_message_id`, not `reply_to_message`

### DIFF
--- a/vxtelegram/telegram.py
+++ b/vxtelegram/telegram.py
@@ -324,8 +324,8 @@ class TelegramTransport(HttpRpcTransport):
 
         # Handle direct replies
         if message['in_reply_to'] is not None:
-            reply_to_message_id = message['transport_metadata']['telegram_msg_id']
-            outbound_msg.update({'reply_to_message_id': reply_to_message_id})
+            telegram_msg_id = message['transport_metadata']['telegram_msg_id']
+            outbound_msg.update({'reply_to_message_id': telegram_msg_id})
 
         url = self.get_outbound_url('sendMessage')
         http_client = HTTPClient(self.agent_factory())

--- a/vxtelegram/telegram.py
+++ b/vxtelegram/telegram.py
@@ -324,8 +324,8 @@ class TelegramTransport(HttpRpcTransport):
 
         # Handle direct replies
         if message['in_reply_to'] is not None:
-            reply_to_message = message['transport_metadata']['telegram_msg_id']
-            outbound_msg.update({'reply_to_message': reply_to_message})
+            reply_to_message_id = message['transport_metadata']['telegram_msg_id']
+            outbound_msg.update({'reply_to_message_id': reply_to_message_id})
 
         url = self.get_outbound_url('sendMessage')
         http_client = HTTPClient(self.agent_factory())

--- a/vxtelegram/tests/test_telegram.py
+++ b/vxtelegram/tests/test_telegram.py
@@ -726,10 +726,11 @@ class TestTelegramTransport(VumiTestCase):
         self.assertEqual(req.path, expected_url)
 
         outbound_msg = json.load(req.content)
+        telegram_msg_id = msg['transport_metadata']['telegram_msg_id']
         self.assert_dict(outbound_msg, {
             'text': msg['content'],
             'chat_id': msg['to_addr'],
-            'reply_to_message_id': msg['transport_metadata']['telegram_msg_id'],
+            'reply_to_message_id': telegram_msg_id,
         })
 
         req.write(json.dumps({'ok': True}))

--- a/vxtelegram/tests/test_telegram.py
+++ b/vxtelegram/tests/test_telegram.py
@@ -148,7 +148,12 @@ class TestTelegramTransport(VumiTestCase):
         a 'down' status.
         """
         error = self.bad_telegram_response['description']
+
+        # When we start this transport, it tries to set up a webhook (and
+        # obviously fails), so we need to publish an 'ok' status after so that
+        # the status we're testing for actually gets published
         transport = yield self.get_transport(publish_status=True)
+        yield transport.add_status_good_webhook()
         d = transport.setup_webhook()
 
         req = yield self.get_next_request()
@@ -164,7 +169,7 @@ class TestTelegramTransport(VumiTestCase):
             )
 
         # Ignore statuses published on transport startup
-        [_, __, status] = yield self.helper.wait_for_dispatched_statuses()
+        [_, __, ___, status] = yield self.helper.wait_for_dispatched_statuses()
         self.assert_dict(status, {
             'status': 'down',
             'component': 'telegram_webhook',
@@ -196,7 +201,7 @@ class TestTelegramTransport(VumiTestCase):
 
         # Ignore statuses published on transport startup (only one, since
         # during tests this status is already published and doesn't repeat)
-        [_, status] = yield self.helper.wait_for_dispatched_statuses()
+        [_, __, status] = yield self.helper.wait_for_dispatched_statuses()
         self.assert_dict(status, {
             'status': 'down',
             'component': 'telegram_webhook',

--- a/vxtelegram/tests/test_telegram.py
+++ b/vxtelegram/tests/test_telegram.py
@@ -724,7 +724,7 @@ class TestTelegramTransport(VumiTestCase):
         self.assert_dict(outbound_msg, {
             'text': msg['content'],
             'chat_id': msg['to_addr'],
-            'reply_to_message': msg['transport_metadata']['telegram_msg_id'],
+            'reply_to_message_id': msg['transport_metadata']['telegram_msg_id'],
         })
 
         req.write(json.dumps({'ok': True}))


### PR DESCRIPTION
Issue is [on this line](https://github.com/praekelt/vumi-telegram/blob/develop/vxtelegram/telegram.py#L328).

When we're replying to a message, we need to include the original message's ID in the request data as `reply_to_message_id`, not `reply_to_message`. 

See https://core.telegram.org/bots/api#sendmessage
