### PR TITLE
Support ForceReply

### DIFF
--- a/vxtelegram/telegram.py
+++ b/vxtelegram/telegram.py
@@ -329,9 +329,7 @@ class TelegramTransport(HttpRpcTransport):
 
         # Handle message formatting options (pass if none are provided)
         try:
-            telegram_metadata = message['helper_metadata']['telegram']
-            for option in telegram_metadata:
-                outbound_msg.update({option: telegram_metadata['option']})
+            outbound_msg.update(message['helper_metadata']['telegram'])
         except KeyError:
             pass
 

--- a/vxtelegram/telegram.py
+++ b/vxtelegram/telegram.py
@@ -327,6 +327,15 @@ class TelegramTransport(HttpRpcTransport):
             reply_to_message = message['transport_metadata']['telegram_msg_id']
             outbound_msg.update({'reply_to_message': reply_to_message})
 
+        # Handle message formatting options (pass if none are provided)
+        try:
+            telegram_metadata = message['helper_metadata']['telegram']
+            for option in telegram_metadata:
+                outbound_msg.update({option: telegram_metadata['option']})
+        except KeyError:
+            pass
+
+
         url = self.get_outbound_url('sendMessage')
         http_client = HTTPClient(self.agent_factory())
 

--- a/vxtelegram/telegram.py
+++ b/vxtelegram/telegram.py
@@ -333,7 +333,6 @@ class TelegramTransport(HttpRpcTransport):
         except KeyError:
             pass
 
-
         url = self.get_outbound_url('sendMessage')
         http_client = HTTPClient(self.agent_factory())
 

--- a/vxtelegram/tests/test_telegram.py
+++ b/vxtelegram/tests/test_telegram.py
@@ -727,6 +727,12 @@ class TestTelegramTransport(VumiTestCase):
             'reply_markup': {'force_reply': True},
         })
 
+        req.write(json.dumps({'ok': True}))
+        req.finish()
+        yield d
+
+        yield self.assert_ack(msg['message_id'])
+
     @inlineCallbacks
     def test_outbound_reply_no_errors(self):
         """


### PR DESCRIPTION
See https://core.telegram.org/bots/api#forcereply

The transport should be able to send messages containing the ForceReply object, to enhance the user experience.