### PR TITLE
Support media attachments in messages

### DIFF
--- a/vxtelegram/telegram.py
+++ b/vxtelegram/telegram.py
@@ -425,7 +425,8 @@ class TelegramTransport(HttpRpcTransport):
         try:
             url = self.get_outbound_url(self.media_api_path[att['type']])
         except KeyError:
-            self.log.info('Unsupported attachment type: %s' % att['type'])
+            self.log.info('Unsupported attachment type: %s' % att.get('type'))
+            return
 
         http_client = HTTPClient(self.agent_factory())
         params = {
@@ -458,7 +459,7 @@ class TelegramTransport(HttpRpcTransport):
         else:
             yield self.outbound_failure(
                 message_id=message_id,
-                message='Media message reply not sent: %s'
+                message='Media message not sent: %s'
                         % validate['message'],
                 status_type=validate['status'],
                 details=validate['details'],

--- a/vxtelegram/telegram.py
+++ b/vxtelegram/telegram.py
@@ -89,9 +89,6 @@ class TelegramTransport(HttpRpcTransport):
         """
         Sets up a webhook to receive updates from Telegram.
         """
-        # NOTE: Telegram currently only supports ports 80, 88, 443 and 8443 for
-        #       webhook setup, and sends requests over HTTPS only. This means
-        #       that a proxy (eg. ngrok, nginx) is needed to run the transport.
         url = self.get_outbound_url('setWebhook')
         http_client = HTTPClient(self.agent_factory())
 
@@ -263,10 +260,6 @@ class TelegramTransport(HttpRpcTransport):
         Handles an inbound callback query, fired when a user makes a selection
         on an inline keyboard.
         """
-        # NOTE: Telegram displays a progress bar until answerCallbackQuery
-        #       is called - this means we have to call this method even if we
-        #       don't intend to send anything to the user
-
         self.log.info(
             'TelegramTransport receiving callback query from %s to %s' % (
                 callback_query['from']['username'], self.bot_username))

--- a/vxtelegram/tests/test_telegram.py
+++ b/vxtelegram/tests/test_telegram.py
@@ -348,7 +348,7 @@ class TestTelegramTransport(VumiTestCase):
         yield self.helper.clear_dispatched_statuses()
 
         expected_log = (
-            'TelegramTransport receiving inbound message from %s to %s' %
+            'TelegramTransport receiving message from %s to %s' %
             (self.default_user['username'], self.bot_username)
         )
         update = {
@@ -712,7 +712,6 @@ class TestTelegramTransport(VumiTestCase):
                 'res_code': 400,
             },
         })
-
 
     @inlineCallbacks
     def test_outbound_callback_query_reply_no_errors(self):


### PR DESCRIPTION
We should be able to make use of the following API methods:
- [sendPhoto](https://core.telegram.org/bots/api#sendphoto)
- [sendDocument](https://core.telegram.org/bots/api#senddocument)
- [sendLocation](https://core.telegram.org/bots/api#sendlocation)
- [sendVenue](https://core.telegram.org/bots/api#sendvenue)
- [sendContact](https://core.telegram.org/bots/api#sendcontact)
